### PR TITLE
Use correct case for fieldtypes namespace.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Parfaitementweb\StatamicLanguageIso639Fieldtype;
 
-use Parfaitementweb\StatamicLanguageIso639Fieldtype\FieldTypes\LanguageSelector;
+use Parfaitementweb\StatamicLanguageIso639Fieldtype\Fieldtypes\LanguageSelector;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 


### PR DESCRIPTION
This PR fixes a bug that occured on a linux server, where the difference between the namespace parts `FieldTypes` in the ServiceProvider class and `Fieldtypes` in the LanguageSelector class itself caused an error.